### PR TITLE
message.rawMessage.channel の代わりに message.room を利用する

### DIFF
--- a/src/scripts/character.js
+++ b/src/scripts/character.js
@@ -2,7 +2,7 @@
 //   misc
 //
 // Commands:
-//   hubot characters 
+//   hubot characters
 //
 
 "use strict"
@@ -62,7 +62,7 @@ module.exports = (robot) => {
             const message = format(selected, {
                 "name": res.message.user.name
             });
-            const c = res.message.rawMessage.channel;
+            const c = res.message.room;
             slack.reqAPI("chat.postMessage", {
                 channel: c,
                 text: message,


### PR DESCRIPTION
## :pencil2: 突然すみません
Re:ゼロから始める Advent Calendar 2016 から来ました。
[hubot-characterというpluginを使ってSlack上でレムと戯れる - 日頃の行い](http://arata.hatenadiary.com/entry/2016/12/02/080000) を拝見して、さっそく私が参加している Slack の Team でもレムりんにご登場いただこうと思ったのですが、そのままでは利用できなかったので、修正した分を Pull Request させていただきました。

## :ticket: issues
現象については下記 issue をご覧ください。
[Private Channel の場合 message.rawMessage が undefined となっている · Issue #1 · blueberrystream/hubot-character](https://github.com/blueberrystream/hubot-character/issues/1)